### PR TITLE
Use user's location as default map view

### DIFF
--- a/src/views/SensorsMap.vue
+++ b/src/views/SensorsMap.vue
@@ -12,12 +12,21 @@ const nodes = useNodesStore();
 
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
-const region = {
+var region = {
   name: "Nairobi",
   lat: -1.3024146,
   long: 36.7770724,
 };
 const mapContainer = "sensorsMapNetwork";
+
+const setRegion = (geoposition) => {
+  region.name = "";
+  region.lat = geoposition.coords.latitude;
+  region.long = geoposition.coords.longitude;
+
+  setMap();
+};
+
 const setMap = () => {
   var map = L.map(mapContainer).setView([region.lat, region.long], 8);
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -31,28 +40,32 @@ const setMap = () => {
 };
 
 const mark_nodes = async (Leaflet, nodey, map) => {
- if((nodey.length==0)||(nodey==undefined) ){
-  console.log("Inactive Nodes empty")
-  await nodes.getInactiveNodes()
- }
-  
+  if (nodey.length == 0 || nodey == undefined) {
+    console.log("Inactive Nodes empty");
+    await nodes.getInactiveNodes();
+  }
 
   const activeMarkerIcon = L.divIcon({
     className: "mapMarkerIco1",
     html: "<span class='radial-map-marker'><span class='inner'></span></span>",
     iconSize: [48, 48],
-    iconAnchor: [24,24]
-    
+    iconAnchor: [24, 24],
   });
 
   nodey.forEach((node) => {
     const coords = node[2].split(",").map(Number);
-    Leaflet.marker(coords,{icon: activeMarkerIcon}).addTo(map).bindPopup(`<p>${node[0]}</p><p>${node[1]}</p>`);
+    Leaflet.marker(coords, { icon: activeMarkerIcon })
+      .addTo(map)
+      .bindPopup(`<p>${node[0]}</p><p>${node[1]}</p>`);
   });
 };
 
 onMounted(() => {
-  setMap();
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(setRegion, () => {}, {
+      timeout: 10000,
+    });
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
Prompts the user to allow a request to get the current location for browsers that support GeolocationAPI and set the location as the default map view.

No error handling is implemented.  Fallback region is set to `Nairobi`

Closes #5

## Screenshot(s)


<img width="995" alt="Screenshot 2023-07-18 160742" src="https://github.com/gideonmaina/sensors-admin-dashboard/assets/17834362/6e42892f-ef8a-4923-b94c-4085e706fb66">

<img width="1046" alt="Screenshot 2023-07-18 160247" src="https://github.com/gideonmaina/sensors-admin-dashboard/assets/17834362/f274bb83-4135-4693-b31b-cfa7e6185cc8">
